### PR TITLE
Fix cannot find module ./colorScales.json

### DIFF
--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -1,5 +1,5 @@
 const React = require('react');
-var Plotly = require('plotly.js/dist/plotly.js');
+var Plotly = require('plotly.js');
 const shallowEqual = require('shallowequal');
 const deepEqual = require('deep-equal');
 


### PR DESCRIPTION
Error: Cannot find module './colorScales.json' caused due to importing from the wrong directory
