### PR TITLE
Fix layout bugs caused by plotly cruft

### DIFF
--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -43,6 +43,10 @@ var PlotlyComponent = React.createClass({
   },
 
   componentWillUnmount: function() {
+    //Remove some cruft left behind by plotly
+    var cruft = document.getElementById("js-plotly-tester");
+    cruft.parentNode.removeChild(cruft);
+
     this.container.removeAllListeners('plotly_click');
     this.container.removeAllListeners('plotly_beforehover');
     this.container.removeAllListeners('plotly_hover');


### PR DESCRIPTION
Plotly creates some additional cruft in the DOM when rendering its graphs. When the graph has been unmounted, the cruft remains and magically interferes with the rest of my layout, specifically the `<AppBar>` component from material-ui.

This pull request fixes that issue by removing the cruft automatically when unmounting graphs.
