### PR TITLE
Don't try to remove cruft if null

### DIFF
--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -45,7 +45,9 @@ var PlotlyComponent = React.createClass({
   componentWillUnmount: function() {
     //Remove some cruft left behind by plotly
     var cruft = document.getElementById("js-plotly-tester");
-    cruft.parentNode.removeChild(cruft);
+    if (cruft !== null) {
+      cruft.parentNode.removeChild(cruft);
+    }
 
     this.container.removeAllListeners('plotly_click');
     this.container.removeAllListeners('plotly_beforehover');


### PR DESCRIPTION
I have been getting a `cannot get parent node of null` error when unmounting the component. This PR will check if cruft is null before attempting to remove it.
