### PR TITLE
resize() function exposed

### DIFF
--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -56,6 +56,10 @@ var PlotlyComponent = React.createClass({
     this.container.removeAllListeners('plotly_selected');
   },
 
+  resize: function() {
+    Plotly.Plots.plot(this.container);
+  },
+
   render: function () {
     let {data, layout, config, ...other } = this.props;
     return <div {...other} ref={(node) => this.container=node} />

--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -57,7 +57,7 @@ var PlotlyComponent = React.createClass({
   },
 
   resize: function() {
-    Plotly.Plots.plot(this.container);
+    Plotly.Plots.resize(this.container);
   },
 
   render: function () {


### PR DESCRIPTION
This supports triggering resize of Plotly graph (e.g. after window resize, orientation change, etc.) from where the component is used:

```
  componentDidMount: function() {
    window.addEventListener('resize', this.onWindowResize);
  },

  componentWillUnmount: function() {
    window.removeEventListener('resize', this.onWindowResize);
  },

  onWindowResize: function() {
    this.refs.plotly.resize();
  },

  render: function() {
    return (
      <Plotly ref="plotly" data={this.state.data} layout={this.state.layout} config={CONFIG}/>
    );
  }
```
