### PR TITLE
React 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "react-plotlyjs",
   "main": "lib/PlotlyComponent.js",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "homepage": "https://github.com/benjeffery/react-plotlyjs",
   "authors": [
     "Ben Jeffery"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plotlyjs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ReactJS / PlotlyJS integration. Draw plotly graphs in your react app.",
   "main": "lib/PlotlyComponent.js",
   "author": "Ben Jeffery",
@@ -24,7 +24,7 @@
     "gulp-util": "^3.0.8"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^15.0.0||^16.0.0"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/benjeffery/react-plotlyjs.git"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -1,17 +1,18 @@
+import PropTypes from 'prop-types';
 import React  from 'react';
 import cloneDeep from 'lodash.clonedeep';
 
 let createPlotlyComponent = (plotlyInstance) => React.createClass({
   displayName: 'Plotly',
   propTypes: {
-    data: React.PropTypes.array,
-    layout: React.PropTypes.object,
-    config: React.PropTypes.object,
-    onClick: React.PropTypes.func,
-    onBeforeHover: React.PropTypes.func,
-    onHover: React.PropTypes.func,
-    onUnHover: React.PropTypes.func,
-    onSelected: React.PropTypes.func
+    data: PropTypes.array,
+    layout: PropTypes.object,
+    config: PropTypes.object,
+    onClick: PropTypes.func,
+    onBeforeHover: PropTypes.func,
+    onHover: PropTypes.func,
+    onUnHover: PropTypes.func,
+    onSelected: PropTypes.func
   },
 
   attachListeners: function() {

--- a/src/PlotlyComponent.js
+++ b/src/PlotlyComponent.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React  from 'react';
 import cloneDeep from 'lodash.clonedeep';
 
-let createPlotlyComponent = (plotlyInstance) => React.createClass({
-  displayName: 'Plotly',
-  propTypes: {
+let createPlotlyComponent = (plotlyInstance) => class Plotly extends React.Component {
+
+  static propTypes = {
     data: PropTypes.array,
     layout: PropTypes.object,
     config: PropTypes.object,
@@ -13,9 +13,9 @@ let createPlotlyComponent = (plotlyInstance) => React.createClass({
     onHover: PropTypes.func,
     onUnHover: PropTypes.func,
     onSelected: PropTypes.func
-  },
+  };
 
-  attachListeners: function() {
+  attachListeners() {
     if (this.props.onClick)
       this.container.on('plotly_click', this.props.onClick);
     if (this.props.onBeforeHover)
@@ -26,18 +26,18 @@ let createPlotlyComponent = (plotlyInstance) => React.createClass({
       this.container.on('plotly_unhover', this.props.onUnHover);
     if (this.props.onSelected)
       this.container.on('plotly_selected', this.props.onSelected);
-  },
+  }
 
   shouldComponentUpdate(nextProps) {
     //TODO logic for detecting change in props
     return true;
-  },
+  }
 
   componentDidMount() {
     let {data, layout, config} = this.props;
     plotlyInstance.newPlot(this.container, data, cloneDeep(layout), config); //We clone the layout as plotly mutates it.
     this.attachListeners();
-  },
+  }
 
   componentDidUpdate(prevProps) {
     //TODO use minimal update for given changes
@@ -46,17 +46,17 @@ let createPlotlyComponent = (plotlyInstance) => React.createClass({
       plotlyInstance.newPlot(this.container, data, cloneDeep(layout), config); //We clone the layout as plotly mutates it.
       this.attachListeners();
     }
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     plotlyInstance.purge(this.container);
-  },
+  }
 
-  resize: function() {
+  resize() {
     plotlyInstance.Plots.resize(this.container);
-  },
+  }
 
-  render: function () {
+  render() {
     let {data, layout, config, ...other } = this.props;
     //Remove props that would cause React to warn for unknown props.
     delete other.onClick;
@@ -67,6 +67,6 @@ let createPlotlyComponent = (plotlyInstance) => React.createClass({
 
     return <div {...other} ref={(node) => this.container=node} />
   }
-});
+};
 
 export default createPlotlyComponent;


### PR DESCRIPTION
Make package future proof.

- Add React 16 as peer dependency
- Use `prop-types` package
- Use ES6 class instead of `React.createClass`